### PR TITLE
Add hooks, sender context, and external messaging support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "@graphql-tools/schema": "^7.1.2",
     "graphql": "^15.4.0",
-    "webextension-polyfill": "^0.7.0"
+    "webextension-polyfill": "^0.7.0",
+    "react": "<=16.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "graphql-tag": "^2.11.0",
     "jest": "^26.6.1",
     "jest-webextension-mock": "^3.7.6",
+    "react": "^17.0.1",
     "typescript": "^4.0.3",
+    "web-ext-types": "^3.2.1",
     "webextension-polyfill": "^0.7.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/preset-typescript": "^7.12.1",
     "@graphql-tools/schema": "^7.1.2",
     "@types/jest": "^26.0.15",
+    "@types/react": "^17.0.0",
     "babel-jest": "^26.6.1",
     "graphql": "^15.4.0",
     "graphql-tag": "^2.11.0",

--- a/src/background.test.ts
+++ b/src/background.test.ts
@@ -40,6 +40,7 @@ describe("TanagerApi", () => {
     expect(resolverMethod).toHaveBeenCalled();
     expect(resolverMethod.mock.calls[0][2]).toEqual({
       source: TanagerMessageSource.Message,
+      sender: undefined,
     });
   });
 
@@ -65,6 +66,7 @@ describe("TanagerApi", () => {
     expect(resolverMethod).toHaveBeenCalled();
     expect(resolverMethod.mock.calls[0][2]).toEqual({
       source: TanagerMessageSource.ExternalMessage,
+      sender: undefined,
     });
   });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -41,8 +41,8 @@ export class TanagerApi {
       ? this.context(baseContext)
       : {
           source: TanagerMessageSource.Internal,
-          ...(baseContext ?? {}),
           ...this.context,
+          ...(baseContext ?? {}),
         };
   }
 
@@ -83,7 +83,7 @@ export class TanagerApi {
     );
   }
 
-  onMessage(message: TanagerMessage, sender: browser.runtime.MessageSender) {
+  onMessage(message: TanagerMessage, sender?: browser.runtime.MessageSender) {
     if (message.type === TanagerMessageKey.Generic && message.query) {
       const { variables, query } = message;
       return this.query(query, variables ?? {}, {
@@ -95,7 +95,7 @@ export class TanagerApi {
 
   onExternalMessage(
     message: TanagerMessage,
-    sender: browser.runtime.MessageSender
+    sender?: browser.runtime.MessageSender
   ) {
     if (message.type === TanagerMessageKey.Generic && message.query) {
       const { variables, query } = message;

--- a/src/background.ts
+++ b/src/background.ts
@@ -23,7 +23,7 @@ export class TanagerApi {
     ...options
   }: TanagerApiOptions) {
     this.schema = makeExecutableSchema(options);
-    this.context = context ?? {};
+    this.context = context ?? { source: TanagerMessageSource.Internal };
 
     this.onMessage = this.onMessage.bind(this);
     this.onExternalMessage = this.onExternalMessage.bind(this);
@@ -36,12 +36,12 @@ export class TanagerApi {
     }
   }
 
-  private getContext(baseContext: TanagerContextObj = {}) {
+  private getContext(baseContext?: TanagerContextObj) {
     return typeof this.context === "function"
       ? this.context(baseContext)
       : {
           source: TanagerMessageSource.Internal,
-          ...baseContext,
+          ...(baseContext ?? {}),
           ...this.context,
         };
   }
@@ -83,20 +83,25 @@ export class TanagerApi {
     );
   }
 
-  onMessage(message: TanagerMessage) {
+  onMessage(message: TanagerMessage, sender: browser.runtime.MessageSender) {
     if (message.type === TanagerMessageKey.Generic && message.query) {
       const { variables, query } = message;
       return this.query(query, variables ?? {}, {
         source: TanagerMessageSource.Message,
+        sender,
       });
     }
   }
 
-  onExternalMessage(message: TanagerMessage) {
+  onExternalMessage(
+    message: TanagerMessage,
+    sender: browser.runtime.MessageSender
+  ) {
     if (message.type === TanagerMessageKey.Generic && message.query) {
       const { variables, query } = message;
       return this.query(query, variables ?? {}, {
         source: TanagerMessageSource.ExternalMessage,
+        sender,
       });
     }
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -54,9 +54,9 @@ export class TanagerApi {
     return print(query);
   }
 
-  async query<T extends {}, V extends GenericVariables>(
+  async query<Query extends {}, Variables extends GenericVariables>(
     query: string | DocumentNode,
-    variables?: V,
+    variables?: Variables,
     baseContext?: TanagerContextObj
   ) {
     const context = this.getContext(baseContext);

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,10 +1,26 @@
-import { queryApi } from './client';
-import browser from 'webextension-polyfill';
+import { queryApi } from "./client";
+import browser from "webextension-polyfill";
+import gql from "graphql-tag";
+import { TanagerMessageKey } from "./types";
 
-describe('queryApi', () => {
-  it('should send and message to the background script', async () => {
+describe("queryApi", () => {
+  it("should send and message to the background script", async () => {
     browser.runtime.sendMessage = jest.fn();
     await queryApi(`{ test }`, {});
     expect(browser.runtime.sendMessage).toBeCalled();
   });
-})
+  it("should send and message to the background script externally", async () => {
+    browser.runtime.sendMessage = jest.fn();
+    const fooQuery = gql`
+      query foo {
+        test
+      }
+    `;
+    await queryApi(fooQuery, {}, { id: "foo" });
+    expect(browser.runtime.sendMessage).toBeCalledWith("foo", {
+      type: TanagerMessageKey.Generic,
+      query: fooQuery,
+      variables: {},
+    });
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,9 +9,9 @@ import {
 } from "./types";
 import { isDocumentNode } from "./utils";
 
-const messageCreator = <V extends GenericVariables = {}>(
+const messageCreator = <Variables extends GenericVariables = {}>(
   query: string | DocumentNode,
-  variables: V
+  variables: Variables
 ) => {
   return {
     type: TanagerMessageKey.Generic,
@@ -21,22 +21,24 @@ const messageCreator = <V extends GenericVariables = {}>(
 };
 
 export const queryApi = async <
-  T extends {} = {},
-  V extends GenericVariables = {}
+  Query extends {} = {},
+  Variables extends GenericVariables = {}
 >(
   query: string | DocumentNode,
-  variables?: V,
+  variables?: Variables,
   options: TanagerQueryOptions = {}
 ) => {
   const { id: extensionId } = options;
   const args:
     | [string, ReturnType<typeof messageCreator>]
     | [ReturnType<typeof messageCreator>] = extensionId
-    ? [extensionId, messageCreator<V>(query, variables)]
-    : [messageCreator<V>(query, variables)];
+    ? [extensionId, messageCreator<Variables>(query, variables)]
+    : [messageCreator<Variables>(query, variables)];
 
-  const resp = browser.runtime.sendMessage<TanagerMessage<V>, T>(...args) as {
-    data: T | null;
+  const resp = browser.runtime.sendMessage<TanagerMessage<Variables>, Query>(
+    ...args
+  ) as {
+    data: Query | null;
     errors?: GraphQLFormattedError[];
   };
   return resp;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,8 @@
 import browser from "webextension-polyfill";
 import { DocumentNode, GraphQLFormattedError } from "graphql";
-import gql from 'graphql-tag';
+import gql from "graphql-tag";
 import { GenericVariables, TanagerMessageKey, TanagerMessage } from "./types";
-import { isDocumentNode } from './utils';
+import { isDocumentNode } from "./utils";
 
 const messageCreator = <V extends GenericVariables = {}>(
   query: string | DocumentNode,
@@ -15,12 +15,25 @@ const messageCreator = <V extends GenericVariables = {}>(
   };
 };
 
-export const queryApi = async <T extends {} = {}, V extends GenericVariables = {}>(
+export const queryApi = async <
+  T extends {} = {},
+  V extends GenericVariables = {}
+>(
   query: string | DocumentNode,
-  variables: V
+  variables?: V,
+  extensionId?: string
 ) => {
-  const resp = browser.runtime.sendMessage<TanagerMessage<V>, T>(
-    messageCreator<V>(query, variables) 
-  ) as { data: T | null, errors?: GraphQLFormattedError[] };
+  const args:
+    | [string, ReturnType<typeof messageCreator>]
+    | [ReturnType<typeof messageCreator>] = [
+    messageCreator<V>(query, variables),
+  ];
+  if (extensionId) {
+    args.unshift(extensionId);
+  }
+  const resp = browser.runtime.sendMessage<TanagerMessage<V>, T>(...args) as {
+    data: T | null;
+    errors?: GraphQLFormattedError[];
+  };
   return resp;
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,12 @@
 import browser from "webextension-polyfill";
 import { DocumentNode, GraphQLFormattedError } from "graphql";
 import gql from "graphql-tag";
-import { GenericVariables, TanagerMessageKey, TanagerMessage } from "./types";
+import {
+  GenericVariables,
+  TanagerMessageKey,
+  TanagerMessage,
+  TanagerQueryOptions,
+} from "./types";
 import { isDocumentNode } from "./utils";
 
 const messageCreator = <V extends GenericVariables = {}>(
@@ -21,13 +26,15 @@ export const queryApi = async <
 >(
   query: string | DocumentNode,
   variables?: V,
-  extensionId?: string
+  options: TanagerQueryOptions = {}
 ) => {
+  const { id: extensionId } = options;
   const args:
     | [string, ReturnType<typeof messageCreator>]
     | [ReturnType<typeof messageCreator>] = extensionId
     ? [extensionId, messageCreator<V>(query, variables)]
     : [messageCreator<V>(query, variables)];
+
   const resp = browser.runtime.sendMessage<TanagerMessage<V>, T>(...args) as {
     data: T | null;
     errors?: GraphQLFormattedError[];

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,12 +25,9 @@ export const queryApi = async <
 ) => {
   const args:
     | [string, ReturnType<typeof messageCreator>]
-    | [ReturnType<typeof messageCreator>] = [
-    messageCreator<V>(query, variables),
-  ];
-  if (extensionId) {
-    args.unshift(extensionId);
-  }
+    | [ReturnType<typeof messageCreator>] = extensionId
+    ? [extensionId, messageCreator<V>(query, variables)]
+    : [messageCreator<V>(query, variables)];
   const resp = browser.runtime.sendMessage<TanagerMessage<V>, T>(...args) as {
     data: T | null;
     errors?: GraphQLFormattedError[];

--- a/src/hooks/ExtensionProvider.ts
+++ b/src/hooks/ExtensionProvider.ts
@@ -2,16 +2,21 @@ import { createElement, createContext, FC, useContext } from "react";
 
 interface ExtensionProviderProps {
   id?: string;
+  port?: browser.runtime.Port;
 }
 
-const context = createContext({ id: undefined });
+const context = createContext<ExtensionProviderProps>({
+  id: undefined,
+  port: undefined,
+});
 const { Provider } = context;
 
 export const ExtensionProvider: FC<ExtensionProviderProps> = ({
   id,
   children,
+  port,
 }) => {
-  return createElement(Provider, { value: { id }, children });
+  return createElement(Provider, { value: { id, port }, children });
 };
 
 export const useExtension = () => {

--- a/src/hooks/ExtensionProvider.ts
+++ b/src/hooks/ExtensionProvider.ts
@@ -1,0 +1,19 @@
+import { createElement, createContext, FC, useContext } from "react";
+
+interface ExtensionProviderProps {
+  id?: string;
+}
+
+const context = createContext({ id: undefined });
+const { Provider } = context;
+
+export const ExtensionProvider: FC<ExtensionProviderProps> = ({
+  id,
+  children,
+}) => {
+  return createElement(Provider, { value: { id }, children });
+};
+
+export const useExtension = () => {
+  return useContext(context);
+};

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -1,0 +1,60 @@
+import { queryApi } from "../client";
+import { DocumentNode, GraphQLFormattedError } from "graphql";
+import { useState, useEffect, useCallback, useRef } from "react";
+
+type MutationError = GraphQLFormattedError | Error;
+type Response<T> = { data: T | null; errors?: GraphQLFormattedError[] } | null;
+
+export const useMutation = <T, V>(
+  query: DocumentNode
+): [
+  (variables: V) => Promise<Response<T>>,
+  { data: T | null; loading: Boolean; error?: MutationError }
+] => {
+  const mounted = useRef(true);
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<MutationError | undefined>();
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const makeMutation = useCallback(
+    async (argVars: V) => {
+      setLoading(true);
+      let resp: Response<T> | null = null;
+      try {
+        resp = await queryApi<T, V>(query, argVars);
+        if (resp.data && mounted.current) {
+          setData(resp.data);
+        }
+        if (resp.errors && resp.errors.length) {
+          setError(resp.errors[0]);
+        }
+      } catch (e) {
+        if (mounted.current) {
+          setError(e);
+        }
+      } finally {
+        if (mounted.current) {
+          setLoading(false);
+        }
+      }
+      return resp;
+    },
+    [query]
+  );
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  return [
+    makeMutation,
+    {
+      data,
+      error,
+      loading,
+    },
+  ];
+};

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -16,7 +16,7 @@ export const useMutation = <T, V>(
     error?: MutationError;
   }
 ] => {
-  const { id } = useExtension();
+  const { id, port } = useExtension();
   const mounted = useRef(true);
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<MutationError | undefined>();
@@ -27,7 +27,7 @@ export const useMutation = <T, V>(
       setLoading(true);
       let resp: Response<T> | null = null;
       try {
-        resp = await queryApi<T, V>(query, argVars, id);
+        resp = await queryApi<T, V>(query, argVars, { id, port });
         if (resp.data && mounted.current) {
           setData(resp.data);
         }

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -1,6 +1,7 @@
 import { queryApi } from "../client";
 import { DocumentNode, GraphQLFormattedError } from "graphql";
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useExtension } from "./ExtensionProvider";
 
 type MutationError = GraphQLFormattedError | Error;
 type Response<T> = { data: T | null; errors?: GraphQLFormattedError[] } | null;
@@ -9,8 +10,13 @@ export const useMutation = <T, V>(
   query: DocumentNode
 ): [
   (variables: V) => Promise<Response<T>>,
-  { data: T | null; loading: Boolean; error?: MutationError }
+  {
+    data: T | null;
+    loading: Boolean;
+    error?: MutationError;
+  }
 ] => {
+  const { id } = useExtension();
   const mounted = useRef(true);
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<MutationError | undefined>();
@@ -21,7 +27,7 @@ export const useMutation = <T, V>(
       setLoading(true);
       let resp: Response<T> | null = null;
       try {
-        resp = await queryApi<T, V>(query, argVars);
+        resp = await queryApi<T, V>(query, argVars, id);
         if (resp.data && mounted.current) {
           setData(resp.data);
         }

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -6,28 +6,28 @@ import { useExtension } from "./ExtensionProvider";
 type MutationError = GraphQLFormattedError | Error;
 type Response<T> = { data: T | null; errors?: GraphQLFormattedError[] } | null;
 
-export const useMutation = <T, V>(
+export const useMutation = <Query, Variables>(
   query: DocumentNode
 ): [
-  (variables: V) => Promise<Response<T>>,
+  (variables: Variables) => Promise<Response<Query>>,
   {
-    data: T | null;
+    data: Query | null;
     loading: Boolean;
     error?: MutationError;
   }
 ] => {
   const { id, port } = useExtension();
   const mounted = useRef(true);
-  const [data, setData] = useState<T | null>(null);
+  const [data, setData] = useState<Query | null>(null);
   const [error, setError] = useState<MutationError | undefined>();
   const [loading, setLoading] = useState<boolean>(false);
 
   const makeMutation = useCallback(
-    async (argVars: V) => {
+    async (argVars: Variables) => {
       setLoading(true);
-      let resp: Response<T> | null = null;
+      let resp: Response<Query> | null = null;
       try {
-        resp = await queryApi<T, V>(query, argVars, { id, port });
+        resp = await queryApi<Query, Variables>(query, argVars, { id, port });
         if (resp.data && mounted.current) {
           setData(resp.data);
         }

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -10,20 +10,20 @@ interface BackgroundQueryOptions<V> {
 
 type QueryError = GraphQLFormattedError | Error;
 
-export const useQuery = <T, V>(
+export const useQuery = <Query, Variables>(
   query: DocumentNode,
-  { skip, variables }: BackgroundQueryOptions<V> = {}
+  { skip, variables }: BackgroundQueryOptions<Variables> = {}
 ) => {
   const { id } = useExtension();
   const mounted = useRef(true);
-  const [data, setData] = useState<T | null>(null);
+  const [data, setData] = useState<Query | null>(null);
   const [error, setError] = useState<QueryError | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
   const makeQuery = useCallback(
-    async (argVars?: V) => {
+    async (argVars?: Variables) => {
       try {
-        const resp = await queryApi<T, V>(
+        const resp = await queryApi<Query, Variables>(
           query,
           // @ts-ignore variables are kinda weird
           argVars ?? variables ?? {},

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,6 +1,7 @@
 import { queryApi } from "../client";
 import { DocumentNode, GraphQLFormattedError } from "graphql";
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useExtension } from "./ExtensionProvider";
 
 interface BackgroundQueryOptions<V> {
   variables?: V;
@@ -13,6 +14,7 @@ export const useQuery = <T, V>(
   query: DocumentNode,
   { skip, variables }: BackgroundQueryOptions<V> = {}
 ) => {
+  const { id } = useExtension();
   const mounted = useRef(true);
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<QueryError | null>(null);
@@ -21,8 +23,12 @@ export const useQuery = <T, V>(
   const makeQuery = useCallback(
     async (argVars?: V) => {
       try {
-        // @ts-ignore variables are kinda weird
-        const resp = await queryApi<T, V>(query, argVars ?? variables ?? {});
+        const resp = await queryApi<T, V>(
+          query,
+          // @ts-ignore variables are kinda weird
+          argVars ?? variables ?? {},
+          id
+        );
 
         if (resp.data && mounted.current) {
           setData(resp.data);

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -1,0 +1,66 @@
+import { queryApi } from "../client";
+import { DocumentNode, GraphQLFormattedError } from "graphql";
+import { useState, useEffect, useCallback, useRef } from "react";
+
+interface BackgroundQueryOptions<V> {
+  variables?: V;
+  skip?: Boolean;
+}
+
+type QueryError = GraphQLFormattedError | Error;
+
+export const useQuery = <T, V>(
+  query: DocumentNode,
+  { skip, variables }: BackgroundQueryOptions<V> = {}
+) => {
+  const mounted = useRef(true);
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<QueryError | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const makeQuery = useCallback(
+    async (argVars?: V) => {
+      try {
+        // @ts-ignore variables are kinda weird
+        const resp = await queryApi<T, V>(query, argVars ?? variables ?? {});
+
+        if (resp.data && mounted.current) {
+          setData(resp.data);
+        }
+        if (resp.errors && resp.errors.length) {
+          setError(resp.errors[0]);
+        }
+      } catch (e) {
+        if (mounted.current) {
+          setError(e);
+        }
+      } finally {
+        if (mounted.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [query, variables]
+  );
+
+  useEffect(() => {
+    if (!skip) {
+      setLoading(true);
+      makeQuery();
+    }
+  }, [query, skip]);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  return {
+    data,
+    error,
+    loading,
+    refetch: makeQuery,
+  };
+};

--- a/src/hooks/useQuery.ts
+++ b/src/hooks/useQuery.ts
@@ -3,8 +3,8 @@ import { DocumentNode, GraphQLFormattedError } from "graphql";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useExtension } from "./ExtensionProvider";
 
-interface BackgroundQueryOptions<V> {
-  variables?: V;
+interface BackgroundQueryOptions<Variables> {
+  variables?: Variables;
   skip?: Boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,3 +36,8 @@ export interface TanagerMessage<T extends GenericVariables = {}> {
   query?: string | DocumentNode;
   variables?: T;
 }
+
+export interface TanagerQueryOptions {
+  id?: string;
+  port?: browser.runtime.Port;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { DocumentNode } from "graphql";
 import { makeExecutableSchema } from "@graphql-tools/schema";
+import browser from "webextension-polyfill";
 
 export enum TanagerMessageKey {
   Generic = "Tanager-message",
@@ -12,7 +13,11 @@ export enum TanagerMessageSource {
 }
 
 export type GenericVariables = { [key: string]: any };
-export type TanagerContextObj = { [key: string]: any };
+export type TanagerContextObj = {
+  source: TanagerMessageSource;
+  sender?: browser.runtime.MessageSender;
+  [key: string]: any;
+};
 export type TanagerContext =
   | TanagerContextObj
   | ((obj: TanagerContextObj) => TanagerContextObj);

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,10 +31,10 @@ export type TanagerApiOptions = {
   typeDefs: MakeExecSchemaOptions["typeDefs"] | DocumentNode[];
 } & MakeExecSchemaOptions;
 
-export interface TanagerMessage<T extends GenericVariables = {}> {
+export interface TanagerMessage<Variables extends GenericVariables = {}> {
   type?: TanagerMessageKey.Generic;
   query?: string | DocumentNode;
-  variables?: T;
+  variables?: Variables;
 }
 
 export interface TanagerQueryOptions {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "declaration": true,
     "downlevelIteration": true,
     "lib": ["es2019", "dom"],
-    "rootDir": "src"
+    "rootDir": "src",
+    "typeRoots": ["node_modules/@types", "node_modules/web-ext-types"],
   },
   "dir": "src",
   "include": ["./src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2965,7 +2965,7 @@ jest@^26.6.1:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -3125,6 +3125,13 @@ lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+loose-envify@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lower-case@^2.0.2:
   version "2.0.2"
@@ -3345,6 +3352,11 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -3576,6 +3588,14 @@ react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
+react@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
+  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -4366,6 +4386,11 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+web-ext-types@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-ext-types/-/web-ext-types-3.2.1.tgz#3edc0e3c2e8fe121d7d7e4ca0b7ee0c883cea832"
+  integrity sha512-oQZYDU3W8X867h8Jmt3129kRVKklz70db40Y6OzoTTuzOJpF/dB2KULJUf0txVPyUUXuyzV8GmT3nVvRHoG+Ew==
 
 webextension-polyfill@^0.7.0:
   version "0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,6 +1182,19 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.5.tgz#b6ab3bba29e16b821d84e09ecfaded462b816b00"
   integrity sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
+  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
@@ -1721,6 +1734,11 @@ cssstyle@^2.2.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^3.0.2:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
+  integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
# Description

This addes in the sender information into the context of the hook. This is for the resolver to be able to gather more information of the tab that is being used and also to be able to send more messages to the tab that sent the original message. This also now includes the hooks to be able to talk to the graphql api as well as support for using this to send external messages.


