### PR TITLE
Rename repo and remove pollyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Tanager Graphql
+# Finch Graphql
 
-Tanager is a library that allows you to build up a local graphql that is accessible via messaging. The is currently setup to use browser messages between the background process of a web extension and its client scripts.
+Finch is a library that allows you to build up a local graphql that is accessible via messaging. The is currently setup to use browser messages between the background process of a web extension and its client scripts.
 
 ```shell
-npm install --save tanager-graphql
+npm install --save finch-graphql
 # or
-yarn add tanager-graphql
+yarn add finch-graphql
 ```
 
 ## Build out an API
@@ -13,7 +13,7 @@ yarn add tanager-graphql
 The `TanagerApi` class is a class that allows you to create an executable graphql schema. It is modeled to look just like the `ApolloServer` class. The only required properties in the options are `typeDefs` and `resolvers`.
 
 ```typescript
-import { TanagerApi } from 'tanager-graphql'
+import { TanagerApi } from "finch-graphql";
 
 // Define your schema
 const typeDefs = `
@@ -34,11 +34,11 @@ const typeDefs = `
 const resolvers = {
   Browser: (parent, { input }) => {
     return browser.premissions.contains(input);
-  }
+  },
 };
 
 // Create the executable schema
-const api = new TanagerApi({
+const api = new FinchApi({
   typeDefs,
   resolver,
 });
@@ -49,7 +49,7 @@ const api = new TanagerApi({
 If you do not have any existing messages you may use the `attachMessages` option to automatically attach to the runtume messages. If you have existing messages you will want to setup up the manual handler to ensure you are able to resolve async resolvers.
 
 ```typescript
-import { TanagerMessageKey } from 'tanager-graphql'; 
+import { FinchMessageKey } from "finch-graphql";
 
 browser.runtime.onMessage.addListener((message) => {
   if (message.type === TanagerMessageKey.Generic) {
@@ -73,7 +73,7 @@ browser.runtime.onExternalMessage.addListener((message) => {
 This is the main reason for this library, it makes it super easy to query large amounts of data from the background script without sending multiple messages.
 
 ```typescript
-import { queryApi } from 'tanager-graphql'
+import { queryApi } from "finch-graphql";
 
 const GetBrowserPermission = `
   query getBrowserPermission($input: PermissionsInput) {
@@ -81,16 +81,13 @@ const GetBrowserPermission = `
       permissions(input: $input)
     }
   }
-`
-
-(async function main() {
+`(async function main() {
   const resp = await queryApi(GetBrowserPermission, {
-    input: { permissions: ['geolocation'] }
-  })
-  
+    input: { permissions: ["geolocation"] },
+  });
+
   if (resp.data?.browser?.permissions) {
     // Do stuff with permissions
   }
-})()
+})();
 ```
-

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-typescript": "^7.12.1",
     "@graphql-tools/schema": "^7.1.2",
+    "@types/chrome": "^0.0.128",
     "@types/jest": "^26.0.15",
     "@types/react": "^17.0.0",
     "babel-jest": "^26.6.1",
@@ -30,13 +31,11 @@
     "jest-webextension-mock": "^3.7.6",
     "react": "^17.0.1",
     "typescript": "^4.0.3",
-    "web-ext-types": "^3.2.1",
-    "webextension-polyfill": "^0.7.0"
+    "web-ext-types": "^3.2.1"
   },
   "peerDependencies": {
     "@graphql-tools/schema": "^7.1.2",
     "graphql": "^15.4.0",
-    "webextension-polyfill": "^0.7.0",
     "react": "<=16.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tanager-graphql",
+  "name": "finch-graphql",
   "version": "0.2.0",
   "description": "Graphql api for you background script of a web extension",
   "main": "dist/index.js",
@@ -8,7 +8,7 @@
     "dist/*.js",
     "dist/*.d.ts"
   ],
-  "repository": "https://github.com/jointoucan/tanager-graphql",
+  "repository": "https://github.com/jointoucan/finch-graphql",
   "author": "Jacob Lowe",
   "license": "MIT",
   "private": false,

--- a/src/background.test.ts
+++ b/src/background.test.ts
@@ -1,10 +1,10 @@
 import gql from "graphql-tag";
-import { TanagerApi } from "./background";
-import { TanagerMessageKey, TanagerMessageSource } from "./types";
+import { FinchApi } from "./background";
+import { FinchMessageKey, FinchMessageSource } from "./types";
 
-describe("TanagerApi", () => {
+describe("FinchApi", () => {
   it("should build up and schema based on typeDefs and resolvers", () => {
-    const api = new TanagerApi({
+    const api = new FinchApi({
       typeDefs: `type Query { test: Boolean! }`,
       resolvers: {
         Query: {
@@ -20,7 +20,7 @@ describe("TanagerApi", () => {
 
   it("should pass along the context of a message when using the message handler", async () => {
     const resolverMethod = jest.fn().mockResolvedValue(true);
-    const api = new TanagerApi({
+    const api = new FinchApi({
       typeDefs: `type Query { test: Boolean! }`,
       resolvers: {
         Query: {
@@ -35,18 +35,18 @@ describe("TanagerApi", () => {
         }
       `,
       variables: {},
-      type: TanagerMessageKey.Generic,
+      type: FinchMessageKey.Generic,
     });
     expect(resolverMethod).toHaveBeenCalled();
     expect(resolverMethod.mock.calls[0][2]).toEqual({
-      source: TanagerMessageSource.Message,
+      source: FinchMessageSource.Message,
       sender: undefined,
     });
   });
 
   it("should pass along the context of an external message when using the external message handler", async () => {
     const resolverMethod = jest.fn().mockResolvedValue(true);
-    const api = new TanagerApi({
+    const api = new FinchApi({
       typeDefs: `type Query { test: Boolean! }`,
       resolvers: {
         Query: {
@@ -61,17 +61,17 @@ describe("TanagerApi", () => {
         }
       `,
       variables: {},
-      type: TanagerMessageKey.Generic,
+      type: FinchMessageKey.Generic,
     });
     expect(resolverMethod).toHaveBeenCalled();
     expect(resolverMethod.mock.calls[0][2]).toEqual({
-      source: TanagerMessageSource.ExternalMessage,
+      source: FinchMessageSource.ExternalMessage,
       sender: undefined,
     });
   });
 
   it("should support passing a document instead of a string", () => {
-    const api = new TanagerApi({
+    const api = new FinchApi({
       typeDefs: `type Query { test: Boolean! }`,
       resolvers: {
         Query: {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,3 @@
-import browser from "webextension-polyfill";
 import { graphql, GraphQLSchema, DocumentNode, print } from "graphql";
 import gql from "graphql-tag";
 import { makeExecutableSchema } from "@graphql-tools/schema";
@@ -12,6 +11,7 @@ import {
   FinchMessageSource,
   FinchContextObj,
 } from "./types";
+import { addExteneralMessageListener, addMessageListener } from "./browser";
 
 export class FinchApi {
   schema: GraphQLSchema;
@@ -29,10 +29,10 @@ export class FinchApi {
     this.onExternalMessage = this.onExternalMessage.bind(this);
 
     if (attachMessages) {
-      browser.runtime.onMessage.addListener(this.onMessage);
+      addMessageListener(this.onMessage);
     }
     if (attachExternalMessages) {
-      browser.runtime.onMessageExternal.addListener(this.onExternalMessage);
+      addExteneralMessageListener(this.onExternalMessage);
     }
   }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,26 +4,26 @@ import gql from "graphql-tag";
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { isDocumentNode } from "./utils";
 import {
-  TanagerApiOptions,
+  FinchApiOptions,
   GenericVariables,
-  TanagerMessage,
-  TanagerMessageKey,
-  TanagerContext,
-  TanagerMessageSource,
-  TanagerContextObj,
+  FinchMessage,
+  FinchMessageKey,
+  FinchContext,
+  FinchMessageSource,
+  FinchContextObj,
 } from "./types";
 
-export class TanagerApi {
+export class FinchApi {
   schema: GraphQLSchema;
-  context: TanagerContext;
+  context: FinchContext;
   constructor({
     context,
     attachMessages,
     attachExternalMessages,
     ...options
-  }: TanagerApiOptions) {
+  }: FinchApiOptions) {
     this.schema = makeExecutableSchema(options);
-    this.context = context ?? { source: TanagerMessageSource.Internal };
+    this.context = context ?? { source: FinchMessageSource.Internal };
 
     this.onMessage = this.onMessage.bind(this);
     this.onExternalMessage = this.onExternalMessage.bind(this);
@@ -36,11 +36,11 @@ export class TanagerApi {
     }
   }
 
-  private getContext(baseContext?: TanagerContextObj) {
+  private getContext(baseContext?: FinchContextObj) {
     return typeof this.context === "function"
       ? this.context(baseContext)
       : {
-          source: TanagerMessageSource.Internal,
+          source: FinchMessageSource.Internal,
           ...this.context,
           ...(baseContext ?? {}),
         };
@@ -57,7 +57,7 @@ export class TanagerApi {
   async query<Query extends {}, Variables extends GenericVariables>(
     query: string | DocumentNode,
     variables?: Variables,
-    baseContext?: TanagerContextObj
+    baseContext?: FinchContextObj
   ) {
     const context = this.getContext(baseContext);
     const documentNode = isDocumentNode(query) ? query : gql(query);
@@ -83,24 +83,24 @@ export class TanagerApi {
     );
   }
 
-  onMessage(message: TanagerMessage, sender?: browser.runtime.MessageSender) {
-    if (message.type === TanagerMessageKey.Generic && message.query) {
+  onMessage(message: FinchMessage, sender?: browser.runtime.MessageSender) {
+    if (message.type === FinchMessageKey.Generic && message.query) {
       const { variables, query } = message;
       return this.query(query, variables ?? {}, {
-        source: TanagerMessageSource.Message,
+        source: FinchMessageSource.Message,
         sender,
       });
     }
   }
 
   onExternalMessage(
-    message: TanagerMessage,
+    message: FinchMessage,
     sender?: browser.runtime.MessageSender
   ) {
-    if (message.type === TanagerMessageKey.Generic && message.query) {
+    if (message.type === FinchMessageKey.Generic && message.query) {
       const { variables, query } = message;
       return this.query(query, variables ?? {}, {
-        source: TanagerMessageSource.ExternalMessage,
+        source: FinchMessageSource.ExternalMessage,
         sender,
       });
     }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,63 @@
+import { FinchMessage } from "./types";
+
+export const addMessageListener = (
+  handler: (
+    message: FinchMessage,
+    sender: browser.runtime.MessageSender | chrome.runtime.MessageSender
+  ) => Promise<unknown>
+) => {
+  if (typeof chrome === "object") {
+    chrome.runtime.onMessage.addListener(handler);
+  } else if (typeof browser === "object") {
+    browser.runtime.onMessage.addListener(handler);
+  }
+};
+
+export const addExteneralMessageListener = (
+  handler: (
+    message: FinchMessage,
+    sender: browser.runtime.MessageSender | chrome.runtime.MessageSender
+  ) => Promise<unknown>
+) => {
+  if (typeof chrome === "object") {
+    chrome.runtime.onMessageExternal.addListener(handler);
+  } else if (typeof browser === "object") {
+    browser.runtime.onMessageExternal.addListener(handler);
+  }
+};
+
+export async function sendMessage<MessageReponse extends {}>(
+  message: unknown
+): Promise<MessageReponse>;
+export async function sendMessage<MessageReponse extends {}>(
+  extensionId: string,
+  message: unknown
+): Promise<MessageReponse>;
+export async function sendMessage<MessageReponse extends {}>(
+  extensionId: string | unknown,
+  message?: unknown
+): Promise<MessageReponse> {
+  const args: [unknown] | [string, unknown] = [extensionId];
+  if (typeof message === "object") {
+    args.push(message);
+  }
+
+  if (typeof chrome === "object") {
+    return new Promise((resolve, reject) => {
+      chrome.runtime.sendMessage(...args, (resp: MessageReponse) => {
+        if (chrome.runtime.lastError) {
+          reject(chrome.runtime.lastError);
+        }
+        resolve(resp);
+      });
+    });
+  }
+
+  if (typeof browser === "object") {
+    return browser.runtime.sendMessage(...args) as Promise<MessageReponse>;
+  }
+
+  return Promise.reject(
+    new Error("Cannot send message to extension, this browser is not supported")
+  );
+}

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,7 +1,7 @@
 import { queryApi } from "./client";
 import browser from "webextension-polyfill";
 import gql from "graphql-tag";
-import { TanagerMessageKey } from "./types";
+import { FinchMessageKey } from "./types";
 
 describe("queryApi", () => {
   it("should send and message to the background script", async () => {
@@ -18,7 +18,7 @@ describe("queryApi", () => {
     `;
     await queryApi(fooQuery, {}, { id: "foo" });
     expect(browser.runtime.sendMessage).toBeCalledWith("foo", {
-      type: TanagerMessageKey.Generic,
+      type: FinchMessageKey.Generic,
       query: fooQuery,
       variables: {},
     });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,5 +1,4 @@
 import { queryApi } from "./client";
-import browser from "webextension-polyfill";
 import gql from "graphql-tag";
 import { FinchMessageKey } from "./types";
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -5,12 +5,17 @@ import { FinchMessageKey } from "./types";
 
 describe("queryApi", () => {
   it("should send and message to the background script", async () => {
-    browser.runtime.sendMessage = jest.fn();
+    const ogChrome = window.chrome;
+    window.chrome = undefined;
+    browser.runtime.sendMessage = jest.fn().mockResolvedValue({});
     await queryApi(`{ test }`, {});
     expect(browser.runtime.sendMessage).toBeCalled();
+    window.chrome = ogChrome;
   });
   it("should send and message to the background script externally", async () => {
-    browser.runtime.sendMessage = jest.fn();
+    const ogChrome = window.chrome;
+    window.chrome = undefined;
+    browser.runtime.sendMessage = jest.fn().mockResolvedValue({});
     const fooQuery = gql`
       query foo {
         test
@@ -22,5 +27,18 @@ describe("queryApi", () => {
       query: fooQuery,
       variables: {},
     });
+    window.chrome = ogChrome;
+  });
+
+  it("should send and message to the background script using chrome apis if available", async () => {
+    const ogChrome = window.chrome;
+    chrome.runtime.sendMessage = jest
+      .fn()
+      .mockImplementation((_message: unknown, callback: (resp: {}) => {}) => {
+        callback({});
+      });
+    await queryApi(`{ test }`, {});
+    expect(chrome.runtime.sendMessage).toBeCalled();
+    window.chrome = ogChrome;
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,9 +3,9 @@ import { DocumentNode, GraphQLFormattedError } from "graphql";
 import gql from "graphql-tag";
 import {
   GenericVariables,
-  TanagerMessageKey,
-  TanagerMessage,
-  TanagerQueryOptions,
+  FinchMessageKey,
+  FinchMessage,
+  FinchQueryOptions,
 } from "./types";
 import { isDocumentNode } from "./utils";
 
@@ -14,7 +14,7 @@ const messageCreator = <Variables extends GenericVariables = {}>(
   variables: Variables
 ) => {
   return {
-    type: TanagerMessageKey.Generic,
+    type: FinchMessageKey.Generic,
     query: isDocumentNode(query) ? query : gql(query),
     variables,
   };
@@ -26,7 +26,7 @@ export const queryApi = async <
 >(
   query: string | DocumentNode,
   variables?: Variables,
-  options: TanagerQueryOptions = {}
+  options: FinchQueryOptions = {}
 ) => {
   const { id: extensionId } = options;
   const args:
@@ -35,7 +35,7 @@ export const queryApi = async <
     ? [extensionId, messageCreator<Variables>(query, variables)]
     : [messageCreator<Variables>(query, variables)];
 
-  const resp = browser.runtime.sendMessage<TanagerMessage<Variables>, Query>(
+  const resp = browser.runtime.sendMessage<FinchMessage<Variables>, Query>(
     ...args
   ) as {
     data: Query | null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
-import browser from "webextension-polyfill";
 import { DocumentNode, GraphQLFormattedError } from "graphql";
 import gql from "graphql-tag";
+import { sendMessage } from "./browser";
 import {
   GenericVariables,
   FinchMessageKey,
@@ -29,17 +29,17 @@ export const queryApi = async <
   options: FinchQueryOptions = {}
 ) => {
   const { id: extensionId } = options;
-  const args:
-    | [string, ReturnType<typeof messageCreator>]
-    | [ReturnType<typeof messageCreator>] = extensionId
-    ? [extensionId, messageCreator<Variables>(query, variables)]
-    : [messageCreator<Variables>(query, variables)];
+  const args: [string, unknown] | [unknown] = [
+    messageCreator<Variables>(query, variables),
+  ];
 
-  const resp = browser.runtime.sendMessage<FinchMessage<Variables>, Query>(
-    ...args
-  ) as {
+  if (extensionId) {
+    args.unshift(extensionId);
+  }
+
+  const resp = sendMessage<{
     data: Query | null;
     errors?: GraphQLFormattedError[];
-  };
+  }>(...args);
   return resp;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,42 +2,42 @@ import { DocumentNode } from "graphql";
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import browser from "webextension-polyfill";
 
-export enum TanagerMessageKey {
-  Generic = "Tanager-message",
+export enum FinchMessageKey {
+  Generic = "Finch-message",
 }
 
-export enum TanagerMessageSource {
+export enum FinchMessageSource {
   Internal = "internal",
   Message = "message",
   ExternalMessage = "external-message",
 }
 
 export type GenericVariables = { [key: string]: any };
-export type TanagerContextObj = {
-  source: TanagerMessageSource;
+export type FinchContextObj = {
+  source: FinchMessageSource;
   sender?: browser.runtime.MessageSender;
   [key: string]: any;
 };
-export type TanagerContext =
-  | TanagerContextObj
-  | ((obj: TanagerContextObj) => TanagerContextObj);
+export type FinchContext =
+  | FinchContextObj
+  | ((obj: FinchContextObj) => FinchContextObj);
 
 type MakeExecSchemaOptions = Parameters<typeof makeExecutableSchema>[0];
 
-export type TanagerApiOptions = {
-  context?: TanagerContext;
+export type FinchApiOptions = {
+  context?: FinchContext;
   attachMessages?: boolean;
   attachExternalMessages?: boolean;
   typeDefs: MakeExecSchemaOptions["typeDefs"] | DocumentNode[];
 } & MakeExecSchemaOptions;
 
-export interface TanagerMessage<Variables extends GenericVariables = {}> {
-  type?: TanagerMessageKey.Generic;
+export interface FinchMessage<Variables extends GenericVariables = {}> {
+  type?: FinchMessageKey.Generic;
   query?: string | DocumentNode;
   variables?: Variables;
 }
 
-export interface TanagerQueryOptions {
+export interface FinchQueryOptions {
   id?: string;
   port?: browser.runtime.Port;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 import { DocumentNode } from "graphql";
 import { makeExecutableSchema } from "@graphql-tools/schema";
-import browser from "webextension-polyfill";
 
 export enum FinchMessageKey {
   Generic = "Finch-message",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
-import { DocumentNode } from 'graphql';
+import { DocumentNode } from "graphql";
 
-export const isDocumentNode = (query: string | DocumentNode): query is DocumentNode => {
-  return typeof query === 'object'
-}
-
+export const isDocumentNode = (
+  query: string | DocumentNode
+): query is DocumentNode => {
+  return typeof query === "object";
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1133,12 +1133,37 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/chrome@^0.0.128":
+  version "0.0.128"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.128.tgz#5dbd8b2539a367353fbe4386f119b510105f8b6a"
+  integrity sha512-eGc599TDtersMBW1cSnExHm0IHrXrO5xdk6Sa2Dq30ED+hR1rpT1ez0NNcCgvGO52nmktGfyvd3Uyquzv3LL4g==
+  dependencies:
+    "@types/filesystem" "*"
+    "@types/har-format" "*"
+
+"@types/filesystem@*":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/filesystem/-/filesystem-0.0.29.tgz#ee3748eb5be140dcf980c3bd35f11aec5f7a3748"
+  integrity sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==
+  dependencies:
+    "@types/filewriter" "*"
+
+"@types/filewriter@*":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/filewriter/-/filewriter-0.0.28.tgz#c054e8af4d9dd75db4e63abc76f885168714d4b3"
+  integrity sha1-wFTor02d11205jq8dviFFocU1LM=
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.4.tgz#4ff9f641a7c6d1a3508ff88bc3141b152772e753"
   integrity sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==
   dependencies:
     "@types/node" "*"
+
+"@types/har-format@*":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.5.tgz#4f6648814d0fdcb6a510e3364a9db439a753c4b1"
+  integrity sha512-IG8AE1m2pWtPqQ7wXhFhy6Q59bwwnLwO36v5Rit2FrbXCIp8Sk8E2PfUCreyrdo17STwFSKDAkitVuVYbpEHvQ==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
@@ -4418,11 +4443,6 @@ web-ext-types@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-ext-types/-/web-ext-types-3.2.1.tgz#3edc0e3c2e8fe121d7d7e4ca0b7ee0c883cea832"
   integrity sha512-oQZYDU3W8X867h8Jmt3129kRVKklz70db40Y6OzoTTuzOJpF/dB2KULJUf0txVPyUUXuyzV8GmT3nVvRHoG+Ew==
-
-webextension-polyfill@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz#0df1120ff0266056319ce1a622b09ad8d4a56505"
-  integrity sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Description

This PR introduces the new name of `finch-graphql` this is because `tanager` was a bit difficult to say... Also this makes this package usable from a website since the polyfill was only allows to be used in extensions.
